### PR TITLE
Document GitBucket version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 MCP (Model Context Protocol) server for GitBucket. Enables AI agents to communicate with GitBucket via MCP protocol.
 
+## GitBucket Compatibility
+
+**Supported Versions:** GitBucket 4.42.0 - 4.46.0
+
+| GitBucket Version | Plugin Compatibility | Notes |
+|------------------|---------------------|-------|
+| 4.46.0 | ✅ Full | Current target |
+| 4.45.0 | ✅ Full | Compatible |
+| 4.44.0 | ✅ Full | Compatible |
+| 4.43.0 | ✅ Full | H2 database migration (DB layer only) |
+| 4.42.0 | ✅ Full | Minimum version - Java 17 required |
+| < 4.42.0 | ❌ Incompatible | Java 11 not supported |
+
+**Compatility Verified By:**
+- Plugin.scala trait unchanged between 4.42.0 and 4.46.0
+- All plugin hook signatures stable across versions
+- MergeService.scala `closeIssuesFromMessage()` pattern stable
+
+**Breaking Changes (Historical):**
+- 4.43.0: H2 database 1.x → 2.x migration (DB layer, not Plugin API)
+- 4.42.0: Java 17 requirement (JDK 11 support dropped)
+
 ## What This Does
 
 Exposes GitBucket's issue tracking and project management capabilities through MCP:
@@ -37,6 +59,15 @@ This plugin implements MCP server capabilities:
 - **Prompts**: Workflow templates for spec planning and implementation tracking
 
 AI agents discover and invoke these capabilities through MCP protocol negotiation.
+
+## Known Issues
+
+**GitBucket API Deficiencies (4.42.1 - 4.46.0):**
+- `update_issue()` PATCH endpoint returns 404 (not implemented)
+- `add_labels_to_issue()` POST returns empty array, labels not added
+- `replace_issue_labels()` PUT returns empty array, labels not set
+
+**Workaround:** Add labels during issue creation only. Label management after creation requires GitBucket web UI.
 
 ## License
 


### PR DESCRIPTION
Fixes #1

## Summary

Added GitBucket compatibility documentation to README.md with version compatibility table, breaking changes history, and known API deficiencies.

## Changes

- **Compatibility table**: Documents supported versions (4.42.0 - 4.46.0)
- **Breaking changes**: Java 17 requirement (4.42.0), H2 migration (4.43.0)
- **Known issues**: Documented GitBucket API deficiencies for update_issue and label operations
- **Workarounds**: Added note about adding labels during issue creation only

## Testing

Verified Plugin.scala signatures are identical between 4.42.0 and 4.46.0, confirming Plugin API stability across the supported version range.